### PR TITLE
Update StateMachine.cs

### DIFF
--- a/Runtime/FrankenBit.Utilities/StateMachine.cs
+++ b/Runtime/FrankenBit.Utilities/StateMachine.cs
@@ -133,7 +133,9 @@ namespace FrankenBit.Utilities
         ///     Time in seconds that has passed since the previous update call.
         /// </param>
         public void Update( float deltaTime )
-        {
+        { 
+            if (_currentState != DefaultState.Exit)
+            {
             _currentState.Update( deltaTime );
 
             _usedStates.Clear();
@@ -146,6 +148,7 @@ namespace FrankenBit.Utilities
                 _currentState.Update( deltaTime );
                 _usedStates.Push( _currentState );
                 transition = GetNextTransition();
+            }
             }
         }
 


### PR DESCRIPTION
Fixed the issue causing state machine to go back to Default.Enter after the Default.Exit is called.